### PR TITLE
Fixed various warning

### DIFF
--- a/libs/hybris/include/hybris/dlfcn.h
+++ b/libs/hybris/include/hybris/dlfcn.h
@@ -28,7 +28,7 @@ void *hybris_dlopen(const char *filename, int flag);
 void *hybris_dlsym(void *handle, const char *symbol);
 int   hybris_dlclose(void *handle);
 int   hybris_dladdr(const void *addr, Dl_info *info);
-char *hybris_dlerror(void);
+const char *hybris_dlerror(void);
 
 #ifdef __cplusplus
 }

--- a/libs/hybris/src/cache.c
+++ b/libs/hybris/src/cache.c
@@ -102,7 +102,7 @@ static void cache_update()
 	char *ret = NULL;
 
 	if (!f)
-		return NULL;
+		return;
 
 	/* before searching, we must first determine whether our cache is valid. if
 	 * it isn't, we must discard our results and re-create the cache.

--- a/libs/hybris/src/dlfcn.c
+++ b/libs/hybris/src/dlfcn.c
@@ -42,7 +42,7 @@ int   hybris_dladdr(const void *addr, Dl_info *info)
 }
 
 
-char *hybris_dlerror(void)
+const char *hybris_dlerror(void)
 {
     return android_dlerror();
 }

--- a/libs/hybris/src/hooks.c
+++ b/libs/hybris/src/hooks.c
@@ -21,7 +21,10 @@
 
 #include "hooks_shm.h"
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -162,7 +165,7 @@ extern void __cxa_finalize(void * d);
  * implementation of our internal property handling
  */
 
-int my_system_property_get(const char *name, const char *value)
+int my_system_property_get(const char *name, char *value)
 {
 	return property_get(name, value, NULL);
 }

--- a/libs/hybris/src/hooks_dirent.c
+++ b/libs/hybris/src/hooks_dirent.c
@@ -94,8 +94,7 @@ static int my_versionsort(struct bionic_dirent **a,
 static int my_scandirat(int fd, const char *dir,
                         struct bionic_dirent ***namelist,
                         int (*filter) (const struct bionic_dirent *),
-                        int (*compar) (const struct bionic_dirent **,
-                                       const struct bionic_dirent **))
+                        __compar_fn_t compar)
 {
     struct dirent **namelist_r;
     struct bionic_dirent **result;
@@ -147,8 +146,7 @@ static int my_scandirat(int fd, const char *dir,
 static int my_scandir(const char *dir,
                       struct bionic_dirent ***namelist,
                       int (*filter) (const struct bionic_dirent *),
-                      int (*compar) (const struct bionic_dirent **,
-                                     const struct bionic_dirent **))
+                      __compar_fn_t compar)
 {
     return my_scandirat(AT_FDCWD, dir, namelist, filter, compar);
 }

--- a/libs/hybris/src/hooks_dirent.c
+++ b/libs/hybris/src/hooks_dirent.c
@@ -94,7 +94,8 @@ static int my_versionsort(struct bionic_dirent **a,
 static int my_scandirat(int fd, const char *dir,
                         struct bionic_dirent ***namelist,
                         int (*filter) (const struct bionic_dirent *),
-                        __compar_fn_t compar)
+                        int (*compar) (const struct bionic_dirent **,
+                                       const struct bionic_dirent **))
 {
     struct dirent **namelist_r;
     struct bionic_dirent **result;
@@ -135,7 +136,7 @@ static int my_scandirat(int fd, const char *dir,
             result[nItems++] = filter_r;
         }
         if (nItems && compar != NULL) // sort
-            qsort(result, nItems, sizeof(struct bionic_dirent *), compar);
+            qsort(result, nItems, sizeof(struct bionic_dirent *), (__compar_fn_t) compar);
 
         *namelist = result;
     }
@@ -146,9 +147,10 @@ static int my_scandirat(int fd, const char *dir,
 static int my_scandir(const char *dir,
                       struct bionic_dirent ***namelist,
                       int (*filter) (const struct bionic_dirent *),
-                      __compar_fn_t compar)
+                      int (*compar) (const struct bionic_dirent **,
+                                     const struct bionic_dirent **))
 {
-    return my_scandirat(AT_FDCWD, dir, namelist, filter, compar);
+    return my_scandirat(AT_FDCWD, dir, namelist, filter, (__compar_fn_t) compar);
 }
 
 

--- a/libs/hybris/src/hooks_io.c
+++ b/libs/hybris/src/hooks_io.c
@@ -197,7 +197,7 @@ static struct aFILE* my_fopen(const char *filename, const char *mode)
     if (file == NULL)
         return NULL;
     struct aFILE* afile = (struct aFILE*) malloc(sizeof(struct aFILE));
-    afile->_file = fileno(file);
+    afile->_file = (short) fileno(file);
     afile->actual = file;
     afile->_flags = 0;
     return afile;
@@ -209,7 +209,7 @@ static struct aFILE* my_fdopen(int fd, const char *mode)
     if (file == NULL)
         return NULL;
     struct aFILE* afile = (struct aFILE*) malloc(sizeof(struct aFILE));
-    afile->_file = (short)fileno(file);
+    afile->_file = (short) fileno(file);
     afile->actual = file;
     return afile;
 }

--- a/libs/hybris/src/hooks_io.c
+++ b/libs/hybris/src/hooks_io.c
@@ -186,7 +186,7 @@ static FILE *_get_actual_fp(struct aFILE *fp)
     return fp->actual;
 }
 
-static void my_clearerr(FILE *fp)
+static void my_clearerr(struct aFILE *fp)
 {
     clearerr(_get_actual_fp(fp));
 }
@@ -203,13 +203,13 @@ static struct aFILE* my_fopen(const char *filename, const char *mode)
     return afile;
 }
 
-static struct aFILE* my_fdopen(const char *filename, const char *mode)
+static struct aFILE* my_fdopen(int fd, const char *mode)
 {
-    FILE* file = fdopen(filename, mode);
+    FILE* file = fdopen(fd, mode);
     if (file == NULL)
         return NULL;
     struct aFILE* afile = (struct aFILE*) malloc(sizeof(struct aFILE));
-    afile->_file = fileno(file);
+    afile->_file = (short)fileno(file);
     afile->actual = file;
     return afile;
 }

--- a/libs/hybris/src/hooks_pthread.c
+++ b/libs/hybris/src/hooks_pthread.c
@@ -733,7 +733,7 @@ static pthread_rwlock_t* hybris_set_realrwlock(pthread_rwlock_t *rwlock)
     if (hybris_is_pointer_in_shm((void*)value))
         realrwlock = (pthread_rwlock_t *)hybris_get_shmpointer((hybris_shm_pointer_t)value);
 
-    if ((int)realrwlock <= ANDROID_TOP_ADDR_VALUE_RWLOCK) {
+    if ((unsigned int)realrwlock <= ANDROID_TOP_ADDR_VALUE_RWLOCK) {
         realrwlock = hybris_alloc_init_rwlock();
         *((unsigned int *)rwlock) = (unsigned int) realrwlock;
     }

--- a/libs/hybris/src/hooks_pthread.c
+++ b/libs/hybris/src/hooks_pthread.c
@@ -195,18 +195,6 @@ static int my_pthread_attr_getstacksize(pthread_attr_t const *__attr, size_t *st
     return pthread_attr_getstacksize(realattr, stack_size);
 }
 
-static int my_pthread_attr_setstackaddr(pthread_attr_t *__attr, void *stack_addr)
-{
-    pthread_attr_t *realattr = (pthread_attr_t *) *(unsigned int *) __attr;
-    return pthread_attr_setstackaddr(realattr, stack_addr);
-}
-
-static int my_pthread_attr_getstackaddr(pthread_attr_t const *__attr, void **stack_addr)
-{
-    pthread_attr_t *realattr = (pthread_attr_t *) *(unsigned int *) __attr;
-    return pthread_attr_getstackaddr(realattr, stack_addr);
-}
-
 static int my_pthread_attr_setstack(pthread_attr_t *__attr, void *stack_base, size_t stack_size)
 {
     pthread_attr_t *realattr = (pthread_attr_t *) *(unsigned int *) __attr;
@@ -745,7 +733,7 @@ static pthread_rwlock_t* hybris_set_realrwlock(pthread_rwlock_t *rwlock)
     if (hybris_is_pointer_in_shm((void*)value))
         realrwlock = (pthread_rwlock_t *)hybris_get_shmpointer((hybris_shm_pointer_t)value);
 
-    if (realrwlock <= ANDROID_TOP_ADDR_VALUE_RWLOCK) {
+    if ((int)realrwlock <= ANDROID_TOP_ADDR_VALUE_RWLOCK) {
         realrwlock = hybris_alloc_init_rwlock();
         *((unsigned int *)rwlock) = (unsigned int) realrwlock;
     }
@@ -878,8 +866,6 @@ static struct _hook pthread_hooks[] = {
     {"pthread_attr_getschedparam", my_pthread_attr_getschedparam},
     {"pthread_attr_setstacksize", my_pthread_attr_setstacksize},
     {"pthread_attr_getstacksize", my_pthread_attr_getstacksize},
-    {"pthread_attr_setstackaddr", my_pthread_attr_setstackaddr},
-    {"pthread_attr_getstackaddr", my_pthread_attr_getstackaddr},
     {"pthread_attr_setstack", my_pthread_attr_setstack},
     {"pthread_attr_getstack", my_pthread_attr_getstack},
     {"pthread_attr_setguardsize", my_pthread_attr_setguardsize},

--- a/libs/hybris/src/hooks_shm.c
+++ b/libs/hybris/src/hooks_shm.c
@@ -18,11 +18,14 @@
 
 #include "hooks_shm.h"
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <pthread.h>

--- a/libs/hybris/src/jb/dlfcn.c
+++ b/libs/hybris/src/jb/dlfcn.c
@@ -13,10 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
+
 #include <dlfcn.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <string.h>
+
 #include "linker.h"
 #include "linker_format.h"
 

--- a/libs/hybris/src/properties.c
+++ b/libs/hybris/src/properties.c
@@ -18,6 +18,10 @@
  *
  */
 
+#ifndef __USE_GNU
+#define __USE_GNU
+#endif
+
 #include <stddef.h>
 #include <string.h>
 #include <stdio.h>
@@ -25,11 +29,6 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-
-#ifndef __USE_GNU
-#define __USE_GNU
-#endif
-
 #include <unistd.h>
 #include <errno.h>
 #include <sys/socket.h>

--- a/libs/hybris/src/properties.c
+++ b/libs/hybris/src/properties.c
@@ -25,7 +25,11 @@
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+
+#ifndef __USE_GNU
 #define __USE_GNU
+#endif
+
 #include <unistd.h>
 #include <errno.h>
 #include <sys/socket.h>

--- a/src/client/initial_setup_browser.cpp
+++ b/src/client/initial_setup_browser.cpp
@@ -355,7 +355,7 @@ bool InitialSetupV8Handler::Execute(const CefString& name, CefRefPtr<CefV8Value>
         msgArgs->SetBool(0, args[0]->GetBoolValue());
         handler.GetBrowser()->SendProcessMessage(PID_BROWSER, msg);
         return true;
-    } else if (name == "setAskTosResult" && !args.empty() && args[0]->IsBool()) {
+    } else if (name == "setAskTosResult" && args.size() >= 1 && args[0]->IsBool()) {
         CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("SetAskTosResult");
         CefRefPtr<CefListValue> msgArgs = msg->GetArgumentList();
         msgArgs->SetBool(0, args[0]->GetBoolValue());

--- a/src/client/initial_setup_browser.cpp
+++ b/src/client/initial_setup_browser.cpp
@@ -95,9 +95,9 @@ void InitialSetupBrowserClient::HandlePickFile(std::string const& title, std::st
         std::string outputStdErr;
         ssize_t r;
         if ((r = read(pipes[PIPE_STDOUT][PIPE_READ], ret, 1024)) > 0)
-            outputStdOut += std::string(ret, (size_t) r).c_str();
+            outputStdOut += std::string(ret, (size_t) r);
         if ((r = read(pipes[PIPE_STDERR][PIPE_READ], ret, 1024)) > 0)
-            outputStdErr += std::string(ret, (size_t) r).c_str();
+            outputStdErr += std::string(ret, (size_t) r);
 
         close(pipes[PIPE_STDOUT][PIPE_READ]);
         close(pipes[PIPE_STDERR][PIPE_READ]);
@@ -129,7 +129,7 @@ void InitialSetupBrowserClient::HandleSetupWithFile(std::string const& file) {
     try {
         ExtractHelper::extractApk(file);
         NotifyApkSetupResult(true);
-    } catch (std::runtime_error e) {
+    } catch (std::runtime_error& e) {
         NotifyApkSetupResult(false);
     }
 }
@@ -355,7 +355,7 @@ bool InitialSetupV8Handler::Execute(const CefString& name, CefRefPtr<CefV8Value>
         msgArgs->SetBool(0, args[0]->GetBoolValue());
         handler.GetBrowser()->SendProcessMessage(PID_BROWSER, msg);
         return true;
-    } else if (name == "setAskTosResult" && args.size() >= 1 && args[0]->IsBool()) {
+    } else if (name == "setAskTosResult" && !args.empty() && args[0]->IsBool()) {
         CefRefPtr<CefProcessMessage> msg = CefProcessMessage::Create("SetAskTosResult");
         CefRefPtr<CefListValue> msgArgs = msg->GetArgumentList();
         msgArgs->SetBool(0, args[0]->GetBoolValue());

--- a/src/client/main.cpp
+++ b/src/client/main.cpp
@@ -308,7 +308,7 @@ int main(int argc, char *argv[]) {
         bool found = true;
         try {
             PathHelper::findDataFile("libs/libminecraftpe.so");
-        } catch (std::exception e) {
+        } catch (std::exception& e) {
             found = false;
         }
         if (!found || (argc > 1 && strcmp(argv[1], "setup") == 0)) {
@@ -383,7 +383,7 @@ int main(int argc, char *argv[]) {
     setenv("LC_ALL", "C", 1); // HACK: Force set locale to one recognized by MCPE so that the outdated C++ standard library MCPE uses doesn't fail to find one
 
     Log::trace("Launcher", "Loading native libraries");
-    void* fmodLib = loadLibraryOS(PathHelper::findDataFile("libs/native/libfmod.so.9.6").c_str(), fmod_symbols);
+    void* fmodLib = loadLibraryOS(PathHelper::findDataFile("libs/native/libfmod.so.9.6"), fmod_symbols);
     void* libmLib = loadLibraryOS("libm.so.6", libm_symbols);
     if (fmodLib == nullptr || libmLib == nullptr)
         return -1;
@@ -607,7 +607,7 @@ int main(int argc, char *argv[]) {
             initFunc(client);
     }
 
-    window.setDrawCallback([&client, &window]() {
+    window.setDrawCallback([&window]() {
         if (client->wantToQuit()) {
             delete client;
             window.close();
@@ -619,7 +619,7 @@ int main(int argc, char *argv[]) {
 #endif
         client->update();
     });
-    window.setWindowSizeCallback([&client, pixelSize](int w, int h) {
+    window.setWindowSizeCallback([pixelSize](int w, int h) {
         client->setRenderingSize(w, h);
         client->setUISizeAndScale(w, h, pixelSize);
     });


### PR DESCRIPTION
There are still a few warning left like:

* `In file included from mcpelauncher-linux/libs/eglut/eglut_x11.c:33:0:
mcpelauncher-linux/libs/eglut/eglutint.h:110:9: note: expected ‘char *’ but argument is of type ‘const char *’
         _eglutReadPNG(char *filename, unsigned int *width, unsigned int *height);`

*  `mcpelauncher-linux/src/minecraft/symbols.cpp:519:28: warning: casting ‘void**’ to ‘void*&’ does not dereference pointer
     ((void*&) AppPlatform::myVtable) = hybris_dlsym(handle, "_ZTV11AppPlatform");`

*  `mcpelauncher-linux/src/client/appplatform.cpp:73:104: warning: converting from ‘mcpe::string (LinuxAppPlatform::*)()’ to ‘void*’ [-Wpmf-conversions]
     replaceVtableEntry(lib, vta, "_ZNK19AppPlatform_android10getDataUrlEv", (void*) &LinuxAppPlatform::getDataUrl);`

* `mcpelauncher-linux/libs/hybris/src/jb/linker.c:1365:25: warning: comparison between pointer and integer
             if(sym_addr == NULL)`

I'm not sure how to handle does. For some we could just disable the warnings.