### PR TITLE
Modified the underlying hook function

### DIFF
--- a/src/common/hook.cpp
+++ b/src/common/hook.cpp
@@ -107,12 +107,17 @@ bool patchLibrary(void* lib, void* sym, void* override) {
     return foundEntry;
 }
 
-void hookFunction(void* symbol, void* hook, void** original) {
+int hookFunction(void* symbol, void* hook, void** original) {
     *original = symbol;
     bool foundEntry = false;
     for (auto& handle : hookLibraries)
         if (patchLibrary(handle.first, symbol, hook))
             foundEntry = true;
-    if (!foundEntry)
+
+    if (!foundEntry) {
         Log::error("Hook", "Failed to hook a symbol (%llu)", (long long int) symbol);
+        return -1;
+    }
+
+    return 0;
 }

--- a/src/common/hook.h
+++ b/src/common/hook.h
@@ -3,4 +3,4 @@
 #include <string>
 
 void addHookLibrary(void* ptr, const std::string& path);
-void hookFunction(void* symbol, void* hook, void** original);
+int hookFunction(void* symbol, void* hook, void** original);


### PR DESCRIPTION
 Modified the underlying hookFunction to comply with the C API (`0` no error or `-1` error). To simplify the test of a hook. Like so `if(!mcpelauncher_hook(...) != 0) printf("Error!")`

Any other suggestion are welcome. Thanks

EDIT: Since, we are going to separate the mod example into his own repository. I deleted the changes from the mod example and only included the hook method changes.